### PR TITLE
Overhauled preloaded data technique

### DIFF
--- a/modules/data_loading_module_test.R
+++ b/modules/data_loading_module_test.R
@@ -1,9 +1,5 @@
 # testing main app module in own shiny app.
-library(shiny)
-library(shinydashboard)
-library(tidyverse)
-library(here)
-
+source(here::here('helpers/load_libraries.R'))
 source(here('modules/data_loading_module.R'))
 
 


### PR DESCRIPTION
Now in order to use preloaded data you simply need to load it into a folder called `data/preloaded` folder. The format of the spreadsheets is the same as you would provide for the manual data entry. The snp specific files (id_to_snp.csv and phewas_results.csv) will go in a folder with the name of whatever snp you are working with (e.g. `rs123456/`). Since the phenome spreadsheet doesn't change it is placed just at `data/preloaded/id_to_code.csv` so it can be shared across the snps you have.  